### PR TITLE
add cast, allow it to build on MSVC in C++ mode

### DIFF
--- a/getopt.h
+++ b/getopt.h
@@ -40,7 +40,7 @@ getopt(int argc, char * const argv[], const char *optstring)
     } else if (!arg || arg[0] != '-' || !isalnum(arg[1])) {
         return -1;
     } else {
-        char *opt = strchr(optstring, arg[optpos]);
+        const char *opt = strchr((char *)optstring, arg[optpos]);
         optopt = arg[optpos];
         if (!opt) {
             if (opterr && *optstring != ':')


### PR DESCRIPTION
Visual C++ has a different prototype for strchr depending whether it builds in C or C++ mode.
This requires adding a cast on the argument to make it compile.
This is documented on this MSDN page.
https://msdn.microsoft.com/en-us/library/b34ccac3.aspx
