### PR TITLE
Shift all non-option arguments to the end

### DIFF
--- a/getopt.h
+++ b/getopt.h
@@ -15,22 +15,77 @@
 #include <stdio.h>
 #include <string.h>
 
-static int optind = 1;
+static int optind = 0;
 static int opterr = 1;
 static int optopt;
 static char *optarg;
 
+/*
+ * Returns 1 if the string at argv[index] follows a valid option flag that
+ * requires an argument, 0 otherwise
+ */
+static
+int is_optarg(char *argv[], int index, const char *optstring)
+{
+    if (index == 1) {
+        return 0;
+    }
+
+    if (argv[index - 1][0] != '-') {
+        return 0;
+    }
+
+    char opt_test = argv[index - 1][1];
+    if (opt_test == '\0') {
+        return 0;
+    }
+
+    char *opt = strchr(optstring, opt_test);
+    if (opt == NULL) {
+        return 0;
+    }
+
+    return opt[1] == ':';
+}
+
+/*
+ * Find any arguments that do not follow an option flag requiring an argument,
+ * and shift them to the end of the argument list
+ */
+static
+void shift_nonopt_args(int argc, char *argv[], const char *optstring)
+{
+    for (int i = 1; i < (argc - 1); i++) {
+        if (argv[i][0] != '-') {
+            if (is_optarg(argv, i, optstring)) {
+                continue;
+            }
+
+            char *temp = argv[i];
+
+            for (int j = i + 1; j < argc; j++) {
+                argv[j - 1] = argv[j];
+            }
+
+            argv[argc - 1] = temp;
+        }
+    }
+}
+
 static int
-getopt(int argc, char * const argv[], const char *optstring)
+getopt(int argc, char * argv[], const char *optstring)
 {
     static int optpos = 1;
-    const char *arg;
+    char *arg;
     (void)argc;
 
     /* Reset? */
     if (optind == 0) {
         optind = 1;
         optpos = 1;
+
+        /* Move all non-option arguments to the end */
+        shift_nonopt_args(argc, argv, optstring);
     }
 
     arg = argv[optind];
@@ -40,7 +95,7 @@ getopt(int argc, char * const argv[], const char *optstring)
     } else if (!arg || arg[0] != '-' || !isalnum(arg[1])) {
         return -1;
     } else {
-        const char *opt = strchr(optstring, arg[optpos]);
+        char *opt = strchr(optstring, arg[optpos]);
         optopt = arg[optpos];
         if (!opt) {
             if (opterr && *optstring != ':')


### PR DESCRIPTION
Hey, I was looking for exactly this for some project that I wanted to work on Linux & Windows (see https://github.com/eriknyquist/BrainfuckIntern), except that I didn't want the non-option arguments to be required at the end, so I added support for having non-option arguments wherever you like. Here it is in case you want to pull it in. Thanks!

Description:

On first invocation, run over the argument list and shift all non-option
arguments to the end of the argument list. This allows non-option
arguments to appear anywhere in the argument list, rather than always
requiring them at the end. Tested on Debian 9 and Windows 10.

