### PR TITLE
Increment optind and optpos after unknown argument

### DIFF
--- a/getopt.h
+++ b/getopt.h
@@ -44,6 +44,10 @@ getopt(int argc, char * const argv[], const char *optstring)
         if (!opt) {
             if (opterr && *optstring != ':')
                 fprintf(stderr, "%s: illegal option: %c\n", argv[0], optopt);
+            if (!arg[++optpos]) {
+                optind++;
+                optpos = 1;
+            }
             return '?';
         } else if (opt[1] == ':') {
             if (arg[optpos + 1]) {
@@ -61,6 +65,10 @@ getopt(int argc, char * const argv[], const char *optstring)
                     fprintf(stderr, 
                             "%s: option requires an argument: %c\n", 
                             argv[0], optopt);
+            if (!arg[++optpos]) {
+                optind++;
+                optpos = 1;
+            }
                 return *optstring == ':' ? ':' : '?';
             }
         } else {

--- a/tests.c
+++ b/tests.c
@@ -114,7 +114,27 @@ test4(void)
     TEST("unknown option", getopt(argc, argv, ":abc") == '?');
     TEST("optopt", optopt == 'y');
     TEST("unknown option stick", getopt(argc, argv, ":abc") == '?');
-    TEST("optopt stick", optopt == 'y');
+}
+
+static void
+test5(void)
+{
+    char *argv[] = {
+        "test5",
+        "-acb",
+        "-c",
+        0
+    };
+    int argc = ARGC(argv);
+
+    optind = 0;
+    TEST("a", getopt(argc, argv, "ab") == 'a');
+    TEST("unknown option", getopt(argc, argv, "ab") == '?');
+    TEST("b", getopt(argc, argv, "ab") == 'b');
+    TEST("unknown option", getopt(argc, argv, "ab") == '?');
+    optind = 2;
+    TEST("missing argument", getopt(argc, argv, ":abc:") == ':');
+    TEST("stop", getopt(argc, argv, "ab") == -1);
 }
 
 int
@@ -126,6 +146,7 @@ main(void)
     test2();
     test3();
     test4();
+    test5();
     printf("%d fail, %d pass\n", count_fail, count_pass);
     return count_fail != 0;
 }


### PR DESCRIPTION
Detecting an unknown or missing argument wouldn't increment neither `optind` nor `optpos`, causing `while` loops to go on forever. This allows a functionality described by the tests as "optopt stick", which I believe is about keeping the `optopt` variable holding the first unknown argument, even after other unknown ones. However, I had to remove this functionality to prevent the possibility of an endless `while` loop, so I want to make a case against it.

"optopt sticking" doesn't seem to be described on POSIX, but I might've not read the `getopt` specification thoroughly. Regardless, this behaviour isn't observed in other implementations of `getopt`, such as GNU and FreeBSD, so it shouldn't be expected here in my opinion. A developer can't fix the endless loop themselves because while `optind` is global, `optpos` is not, therefore he wouldn't be able to increment it if an argument had many options in a single string, for example.

`test0` and `test1` weren't picking this up because arguments were given to all options. `test2`, `test3` and `test4` were only checking for unknown or missing arguments once, not comparable to a loop. I wrote `test5` to confirm the new behaviour.