### PR TITLE
Replace strcmp

### DIFF
--- a/getopt.h
+++ b/getopt.h
@@ -33,7 +33,7 @@ getopt(int argc, char * const argv[], const char *optstring)
     }
 
     arg = argv[optind];
-    if (arg && strcmp(arg, "--") == 0) {
+    if (arg && arg[0] == '-' && arg[1] == '-' && arg[2] == '\0') {
         optind++;
         return -1;
     } else if (!arg || arg[0] != '-' || !isalnum(arg[1])) {


### PR DESCRIPTION
Replace usage of `strcmp`.

If one replaces `strchr` (used in one place) `string.h` can be ditched entirely.

PS: I was inspired by your excellent [review of the C standard library](https://nullprogram.com/blog/2023/02/11/)
> Like ctype.h, string.h is another case where everything is terrible, and some functions are virtually always misused.